### PR TITLE
Fix to issue 5: New prop unique-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,16 +77,17 @@ export default {
 
 #### Properties
 
-| Name                    | Type     | Required | Default         | Info                                                           |
-| ----------------------- | -------- | -------- | --------------- | -------------------------------------------------------------- |
-| **url**                 | String   | True     |                 | Url to POST the files                                          |
-| **thumb-url**           | Function | True     |                 | Method that should returns the thumb url for the uploaded file |
-| **accept**              | String   | False    | .png,.jpg       | File input accept filter                                       |
-| **headers**             | Object   | False    | {}              | Headers for the request. You can pass auth tokens for example  |
-| **btn-label**           | String   | False    | Select a file   | Label for the button                                           |
-| **btn-uploading-label** | String   | False    | Uploading files | Label for the button when the upload is in progress            |
-| **max-size**            | Number   | False    | 15728640 //15Mb | Max size for the file                                          |
-| **additional-data**     | Object   | False    | {}              | Additional data for the request                                |
+| Name                    | Type     | Required | Default         | Info                                                                        |
+| ----------------------- | -------- | -------- | --------------- | --------------------------------------------------------------------------- |
+| **url**                 | String   | True     |                 | Url to POST the files                                                       |
+| **thumb-url**           | Function | True     |                 | Method that should returns the thumb url for the uploaded file              |
+| **accept**              | String   | False    | .png,.jpg       | File input accept filter                                                    |
+| **headers**             | Object   | False    | {}              | Headers for the request. You can pass auth tokens for example               |
+| **btn-label**           | String   | False    | Select a file   | Label for the button                                                        |
+| **btn-uploading-label** | String   | False    | Uploading files | Label for the button when the upload is in progress                         |
+| **max-size**            | Number   | False    | 15728640 //15Mb | Max size for the file                                                       |
+| **additional-data**     | Object   | False    | {}              | Additional data for the request                                             |
+| **unique-id**           | String   | False    | '000'           | Helpful when using more than one instance of the component on the same page |
 
 #### Events
 

--- a/src/FileUpload.vue
+++ b/src/FileUpload.vue
@@ -4,8 +4,8 @@
     .thumb-preview-item
       img(:src='thumbUrl(anexo)')
   .input-wrapper(:style='inputWrapperStyle')
-    input#file-upload-input(type='file', name='file', @change='onChangeInputFile', :accept='accept', :multiple='false', :disabled='uploading', ref='input')
-    label.file-upload-label(for='file-upload-input')
+    input.file-upload-input(:id='fileUploadInputName' type='file', name='file', @change='onChangeInputFile', :accept='accept', :multiple='false', :disabled='uploading', ref='input')
+    label.file-upload-label(:for='fileUploadInputName')
       span.file-upload-icon(:class="{'file-upload-icon-pulse': uploading}") &#x21EA;
       div {{ uploading ? btnUploadingLabel : btnLabel }}
     div.file-upload-progress(:style='progressStyle')
@@ -34,7 +34,8 @@ export default {
         return {}
       }
     },
-    requestType: { type: String, default: 'POST' }
+    requestType: { type: String, default: 'POST' },
+    uniqueId: { type: String, default: '000' }
   },
   data() {
     return {
@@ -54,6 +55,9 @@ export default {
     },
     inputWrapperStyle() {
       return { opacity: this.uploading ? '0.7' : '1' }
+    },
+    fileUploadInputName() {
+      return 'file-upload-input' + this.uniqueId
     }
   },
   methods: {
@@ -123,7 +127,7 @@ export default {
       background-color: #2C70AC;
     }
 
-    #file-upload-input {
+    .file-upload-input {
       width: 0.1px;
       height: 0.1px;
       opacity: 0;


### PR DESCRIPTION
Adds a new property `unique-id`, which can be used to uniquely identify the instance of the component avoiding the problem reported with [issue 5](https://github.com/dflourusso/v-file-upload/issues/5) when 2 or more instances of the component are rendered in the same page.

If only one instance is used, there is no need to set this property.